### PR TITLE
Fix shutdown problem

### DIFF
--- a/include/concore2full/global_thread_pool.h
+++ b/include/concore2full/global_thread_pool.h
@@ -1,12 +1,31 @@
 #pragma once
 
 #include "concore2full/thread_pool.h"
+#include "concore2full/thread_snapshot.h"
 
 namespace concore2full {
 
+namespace detail {
+/// Wrapper around the global thread pool, to be used in the `spawn()` function.
+/// Ensures that shutdown of the global thread pool is done on the same OS thread that started it.
+struct global_thread_pool_wrapper {
+  thread_pool wrapped_;
+  thread_snapshot snapshot_;
+
+  /// Constructs the wrapped thread pool, remembering the OS thread.
+  global_thread_pool_wrapper() = default;
+  /// Reverts the thread snapshot and stops the wrapped thread pool.
+  ~global_thread_pool_wrapper() {
+    snapshot_.revert();
+    wrapped_.request_stop();
+    wrapped_.join();
+  }
+};
+} // namespace detail
+
 inline thread_pool& global_thread_pool() {
-  static thread_pool instance;
-  return instance;
+  static detail::global_thread_pool_wrapper instance;
+  return instance.wrapped_;
 }
 
 } // namespace concore2full


### PR DESCRIPTION
If we end `main` from a worker thread we would go to delete the global thread pool from that worker thread. Trying to destroy that global thread pool from one of its working thread can lead to deadlocks.

Made sure that we go back on the original thread pool before destroying the global thread pool.