### PR TITLE
Copy spawn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ if(LIBCPP)
      target_compile_options(concore2full PUBLIC -fexperimental-library)
 endif()
 
+# target_compile_options(concore2full PUBLIC -fsanitize=address,undefined)
+# target_link_options(concore2full PUBLIC -fsanitize=address,undefined)
+
 set(PROFILING_LITE_PATH "INVALID" CACHE PATH "Path towards profiling-lite")
 if(EXISTS "${PROFILING_LITE_PATH}/cxx")
      message(STATUS "Using profiling-lite from: ${PROFILING_LITE_PATH}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,8 @@ if(LIBCPP)
      target_compile_options(concore2full PUBLIC -fexperimental-library)
 endif()
 
-# target_compile_options(concore2full PUBLIC -fsanitize=address,undefined)
-# target_link_options(concore2full PUBLIC -fsanitize=address,undefined)
+# target_compile_options(concore2full PUBLIC -fsanitize=address -fno-omit-frame-pointer)
+# target_link_options(concore2full PUBLIC -fsanitize=address -fno-omit-frame-pointer)
 
 set(PROFILING_LITE_PATH "INVALID" CACHE PATH "Path towards profiling-lite")
 if(EXISTS "${PROFILING_LITE_PATH}/cxx")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(Sources
 src/profiling.cpp
 src/spawn.cpp
 src/spawn_frame_base.cpp
+src/copyable_spawn_frame_base.cpp
 src/bulk_spawn_frame_base.cpp
 src/this_thread.cpp
 src/sleep_helper.cpp

--- a/include/concore2full/detail/copyable_spawn_frame_base.h
+++ b/include/concore2full/detail/copyable_spawn_frame_base.h
@@ -37,6 +37,8 @@ private:
 
   //! The state of the computation, with respect to reaching the await point.
   profiling::atomic<uint32_t> sync_state_;
+  //! The number of threads that reached await.
+  std::atomic<uint32_t> awaiters_count_{0};
 
   //! The suspension point of the first thread to arrive in await.
   continuation_t first_await_;

--- a/include/concore2full/detail/copyable_spawn_frame_base.h
+++ b/include/concore2full/detail/copyable_spawn_frame_base.h
@@ -4,6 +4,7 @@
 #include "concore2full/c/task.h"
 #include "concore2full/detail/callcc.h"
 #include "concore2full/detail/value_holder.h"
+#include "concore2full/profiling_atomic.h"
 #include "concore2full/suspend.h"
 #include "concore2full/this_thread.h"
 
@@ -35,13 +36,13 @@ private:
   struct concore2full_task task_;
 
   //! The state of the computation, with respect to reaching the await point.
-  std::atomic<uint32_t> sync_state_;
+  profiling::atomic<uint32_t> sync_state_;
 
-  //! The suspension point of the originator of the spawn.
-  // continuation_t originator_;
+  //! The suspension point of the first thread to arrive in await.
+  continuation_t first_await_;
 
   //! The suspension point of the thread that is performing the spawned work.
-  // continuation_t secondary_thread_;
+  continuation_t secondary_thread_;
 
   //! The user function to be called to execute the async work.
   concore2full_spawn_function_t user_function_;

--- a/include/concore2full/detail/copyable_spawn_frame_base.h
+++ b/include/concore2full/detail/copyable_spawn_frame_base.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "concore2full/c/spawn.h"
+#include "concore2full/c/task.h"
+#include "concore2full/detail/callcc.h"
+#include "concore2full/detail/value_holder.h"
+#include "concore2full/suspend.h"
+#include "concore2full/this_thread.h"
+
+#include <memory>
+#include <type_traits>
+
+namespace concore2full::detail {
+
+//! Basic structure needed to perform a `spawn` operation.
+struct copyable_spawn_frame_base {
+
+  using interface_t = concore2full_spawn_frame;
+
+  copyable_spawn_frame_base() = default;
+
+  static copyable_spawn_frame_base* from_interface(interface_t* src) {
+    return reinterpret_cast<copyable_spawn_frame_base*>(src);
+  }
+  interface_t* to_interface() { return reinterpret_cast<interface_t*>(this); }
+
+  //! Asynchronously executes `f`.
+  void spawn(concore2full_spawn_function_t f);
+
+  //! Await the async computation started by `spawn` to be finished.
+  void await();
+
+private:
+  //! Describes how to view the spawn data as a task.
+  struct concore2full_task task_;
+
+  //! The state of the computation, with respect to reaching the await point.
+  std::atomic<uint32_t> sync_state_;
+
+  //! The suspension point of the originator of the spawn.
+  // continuation_t originator_;
+
+  //! The suspension point of the thread that is performing the spawned work.
+  // continuation_t secondary_thread_;
+
+  //! The user function to be called to execute the async work.
+  concore2full_spawn_function_t user_function_;
+
+  //! Token that will wake any suspended threads of execution.
+  suspend_token suspend_token_;
+
+private:
+  //! Called when the spawned work is completed.
+  continuation_t on_async_complete(continuation_t c);
+  //! The task function that executes the spawned work.
+  static void execute_spawn_task(concore2full_task* task, int) noexcept;
+};
+
+} // namespace concore2full::detail

--- a/include/concore2full/global_thread_pool.h
+++ b/include/concore2full/global_thread_pool.h
@@ -13,9 +13,10 @@ struct global_thread_pool_wrapper {
   thread_snapshot snapshot_;
 
   /// Constructs the wrapped thread pool, remembering the OS thread.
-  global_thread_pool_wrapper() = default;
+  global_thread_pool_wrapper() { profiling::zone zone{CURRENT_LOCATION()}; }
   /// Reverts the thread snapshot and stops the wrapped thread pool.
   ~global_thread_pool_wrapper() {
+    profiling::zone zone{CURRENT_LOCATION()};
     snapshot_.revert();
     wrapped_.join();
   }

--- a/include/concore2full/profiling_atomic.h
+++ b/include/concore2full/profiling_atomic.h
@@ -83,6 +83,7 @@ template <std::integral T> struct atomic : detail::catomic<T> {
       do_trace(t0, "compare_exchange_weak (success)", v);
     else
       do_trace(t0, "compare_exchange_weak (fail)", expected);
+    return r;
   }
   bool compare_exchange_weak(T& expected, T v, std::memory_order success_order,
                              std::memory_order fail_order) noexcept {
@@ -92,6 +93,7 @@ template <std::integral T> struct atomic : detail::catomic<T> {
       do_trace(t0, "compare_exchange_weak (success)", v);
     else
       do_trace(t0, "compare_exchange_weak (fail)", expected);
+    return r;
   }
   bool compare_exchange_strong(T& expected, T v, std::memory_order success_order,
                                std::memory_order fail_order) volatile noexcept {
@@ -101,6 +103,7 @@ template <std::integral T> struct atomic : detail::catomic<T> {
       do_trace(t0, "compare_exchange_strong (success)", v);
     else
       do_trace(t0, "compare_exchange_strong (fail)", expected);
+    return r;
   }
   bool compare_exchange_strong(T& expected, T v, std::memory_order success_order,
                                std::memory_order fail_order) noexcept {
@@ -110,6 +113,7 @@ template <std::integral T> struct atomic : detail::catomic<T> {
       do_trace(t0, "compare_exchange_strong (success)", v);
     else
       do_trace(t0, "compare_exchange_strong (fail)", expected);
+    return r;
   }
   bool
   compare_exchange_weak(T& expected, T v,
@@ -120,6 +124,7 @@ template <std::integral T> struct atomic : detail::catomic<T> {
       do_trace(t0, "compare_exchange_weak (success)", v);
     else
       do_trace(t0, "compare_exchange_weak (fail)", expected);
+    return r;
   }
   bool compare_exchange_weak(T& expected, T v,
                              std::memory_order order = std::memory_order_seq_cst) noexcept {
@@ -129,6 +134,7 @@ template <std::integral T> struct atomic : detail::catomic<T> {
       do_trace(t0, "compare_exchange_weak (success)", v);
     else
       do_trace(t0, "compare_exchange_weak (fail)", expected);
+    return r;
   }
   bool
   compare_exchange_strong(T& expected, T v,
@@ -139,6 +145,7 @@ template <std::integral T> struct atomic : detail::catomic<T> {
       do_trace(t0, "compare_exchange_strong (success)", v);
     else
       do_trace(t0, "compare_exchange_strong (fail)", expected);
+    return r;
   }
   bool compare_exchange_strong(T& expected, T v,
                                std::memory_order order = std::memory_order_seq_cst) noexcept {
@@ -148,6 +155,7 @@ template <std::integral T> struct atomic : detail::catomic<T> {
       do_trace(t0, "compare_exchange_strong (success)", v);
     else
       do_trace(t0, "compare_exchange_strong (fail)", expected);
+    return r;
   }
 
   void wait(T v, std::memory_order order = std::memory_order_seq_cst) const volatile noexcept {
@@ -262,8 +270,13 @@ template <std::integral T> struct atomic : detail::catomic<T> {
   T operator^=(T v) noexcept { return fetch_xor(v) ^ v; }
 
 private:
+#if USE_PROFILING_LITE
   using timestamp_t = profiling_lite::timestamp_t;
   static timestamp_t now() { return profiling_lite::now(); }
+#else
+  using timestamp_t = uint64_t;
+  static timestamp_t now() { return 0; }
+#endif
 
   void do_trace(timestamp_t t0, std::string_view name, T value) const {
 #if USE_PROFILING_LITE

--- a/include/concore2full/spawn.h
+++ b/include/concore2full/spawn.h
@@ -2,6 +2,7 @@
 
 #include "concore2full/c/spawn.h"
 #include "concore2full/detail/bulk_spawn_frame_full.h"
+#include "concore2full/detail/copyable_spawn_frame_base.h"
 #include "concore2full/detail/frame_with_value.h"
 #include "concore2full/detail/shared_frame.h"
 #include "concore2full/detail/spawn_frame_base.h"
@@ -33,6 +34,14 @@ template <std::invocable Fn> inline auto spawn(Fn&& f) {
 template <std::invocable Fn> inline auto escaping_spawn(Fn&& f) {
   using frame_holder_t =
       detail::shared_frame<detail::frame_with_value<detail::spawn_frame_base, Fn>>;
+  return future<frame_holder_t>{detail::start_spawn_t{}, std::forward<Fn>(f)};
+}
+
+//! Same as `spawn`, but the returned future can be copied and moved.
+//! The caller is responsible for calling `await` exactly once on each copy of the returned object.
+template <std::invocable Fn> inline auto copyable_spawn(Fn&& f) {
+  using frame_holder_t =
+      detail::shared_frame<detail::frame_with_value<detail::copyable_spawn_frame_base, Fn>>;
   return future<frame_holder_t>{detail::start_spawn_t{}, std::forward<Fn>(f)};
 }
 

--- a/include/concore2full/suspend.h
+++ b/include/concore2full/suspend.h
@@ -17,11 +17,21 @@ private:
   std::stop_source stop_source_;
 
   friend void suspend(suspend_token& token);
+  friend void suspend_quick_resume(suspend_token& token);
 };
 
 //! Suspends the current execution until `token` is notified.
 //!
+//! If the thread pool is executing something, then the suspend may not return immediatelly.
 //! This will allow the thread pool to use the current thread for other activities.
 void suspend(suspend_token& token);
+
+//! Suspends the current execution until `token` is notified; when notified, the execution will
+//! continue asap.
+//!
+//! If the thread pool is executing something, this will not wait until the task is done; it will
+//! quickly continue by spawning a new task. While suspended, this will allow the thread pool to use
+//! the current thread for other activities.
+void suspend_quick_resume(suspend_token& token);
 
 } // namespace concore2full

--- a/include/concore2full/thread_pool.h
+++ b/include/concore2full/thread_pool.h
@@ -62,6 +62,7 @@ public:
   void offer_help_until(std::stop_token stop_condition) noexcept;
 
   //! Stops executing more work and waits for all the threads to complete.
+  //! Note: must not be called from a thread that was originally part of the thread pool.
   void join() noexcept;
 
   //! Returns the number of threads in `this`.

--- a/src/copyable_spawn_frame_base.cpp
+++ b/src/copyable_spawn_frame_base.cpp
@@ -15,16 +15,22 @@ using concore2full::detail::copyable_spawn_frame_base;
 /*
 Valid transitions:
 ss_initial_state -> ss_async_started --> ss_async_finished
+                                     \-> ss_main_finishing -> ss_main_finished ->
+ss_async_finished_after_main
 */
 enum sync_state_values {
   ss_initial_state = 0,
   ss_async_started,
   ss_async_finished,
+  ss_main_finishing,
+  ss_main_finished,
+  ss_async_finished_after_main,
 };
 
 } // namespace
 
 void copyable_spawn_frame_base::spawn(concore2full_spawn_function_t f) {
+  sync_state_.set_name("sync_state");
   task_.task_function_ = &execute_spawn_task;
   task_.next_ = nullptr;
   sync_state_ = ss_initial_state;
@@ -33,26 +39,85 @@ void copyable_spawn_frame_base::spawn(concore2full_spawn_function_t f) {
 }
 void copyable_spawn_frame_base::await() {
   concore2full::profiling::zone zone{CURRENT_LOCATION()};
-  // If the async work has already finished, complete directly.
-  if (sync_state_.load(std::memory_order_acquire) == ss_async_finished) {
-    return;
-  }
+  // If the async work hasn't started yet, check if we can execute it here directly.
+  // if (sync_state_.load(std::memory_order_acquire) == ss_initial_state) {
+  //   if (concore2full::global_thread_pool().extract_task(&task_)) {
+  //     concore2full::profiling::zone z{CURRENT_LOCATION_N("execute inplace")};
+  //     // We've extracted the task from the queue; execute it here directly.
+  //     user_function_(to_interface());
+  //     // We are done.
+  //     return;
 
-  // Suspend the current thread; let the worker wake us up,
-  suspend(suspend_token_);
+  //     // TODO: what about the followup awaits?
+  //   }
+  //   // If we are here, the task was already started by the thread pool.
+  //   // Wait for it to store the continuation object.
+  //   concore2full::detail::atomic_wait(sync_state_, [](int v) { return v >= ss_async_started; });
+  // }
+
+  // TODO
+  concore2full::detail::atomic_wait(sync_state_, [](int v) { return v >= ss_async_started; });
+
+  uint32_t expected{ss_async_started};
+  if (sync_state_.compare_exchange_strong(expected, ss_main_finishing)) {
+    // We are the first to finish; we need to start switching threads.
+    auto c = callcc([this](continuation_t await_cc) -> continuation_t {
+      first_await_ = await_cc;
+      // We are done "finishing".
+      sync_state_.store(ss_main_finished, std::memory_order_release);
+      // Complete the thread switching.
+      return secondary_thread_;
+    });
+    (void)c;
+  } else {
+    // We are not the first to arrive here; either the async work finished, or another thread
+    // reached the await point before us.
+    if (expected == ss_async_finished) {
+      // The async thread finished; we can continue directly, no need to switch threads.
+      return;
+    } else {
+      // There is another await that arrived before us; but we still need to wait for the async work
+      // to finish
+      concore2full::profiling::zone zone{CURRENT_LOCATION_N("waiting on both")};
+
+      // If the async work has already finished, complete directly.
+      auto state = sync_state_.load(std::memory_order_acquire);
+      if (state == ss_async_finished || state == ss_async_finished_after_main) {
+        return;
+      }
+
+      // Suspend the current thread; let the worker wake us up,
+      suspend(suspend_token_);
+    }
+  }
 }
 
 //! Called when the async work is finished, to see if we need a thread switch.
 continuation_t copyable_spawn_frame_base::on_async_complete(continuation_t c) {
   concore2full::profiling::zone zone{CURRENT_LOCATION()};
 
-  // Tell the world that the computation has finished.
-  sync_state_.store(ss_async_finished, std::memory_order_release);
+  uint32_t expected{ss_async_started};
+  if (sync_state_.compare_exchange_strong(expected, ss_async_finished)) {
+    // We are first to arrive at completion.
+    // We won't need any thread switch, so we can safely exit.
+    // Return the original continuation.
+    return c;
+  } else {
+    // There is at least one `await` that arrived before us; we need a thread swtich.
 
-  // Notify all the waiting futures.
-  suspend_token_.notify();
-  // TODO: the `this` object might become invalid if all the futures are destroyed.
-  return c;
+    // If the await thread is currently finishing, wait for it to finish.
+    // We need the main thread to properly set `first_await_` continuation.
+    concore2full::detail::atomic_wait(sync_state_, [](int v) { return v == ss_main_finished; });
+
+    // Tell the world that the computation has finished.
+    sync_state_.store(ss_async_finished_after_main, std::memory_order_release);
+
+    // Notify all the waiting futures.
+    suspend_token_.notify();
+
+    // Finish the thread switch.
+    return first_await_;
+  }
 }
 
 //! The task function that executes the async work.
@@ -61,9 +126,9 @@ void copyable_spawn_frame_base::execute_spawn_task(concore2full_task* task, int)
       (copyable_spawn_frame_base*)((char*)task - offsetof(copyable_spawn_frame_base, task_));
   (void)callcc([self](continuation_t thread_cont) -> continuation_t {
     // Assume there will be a thread switch and store required objects.
-    // self->secondary_thread_ = thread_cont;
+    self->secondary_thread_ = thread_cont;
     // Signal the fact that we have started (and the continuation is properly stored).
-    atomic_store_explicit(&self->sync_state_, ss_async_started, std::memory_order_release);
+    self->sync_state_.store(ss_async_started, std::memory_order_release);
     // Actually execute the given work.
     self->user_function_(self->to_interface());
     // Complete the async processing.

--- a/src/copyable_spawn_frame_base.cpp
+++ b/src/copyable_spawn_frame_base.cpp
@@ -1,0 +1,72 @@
+#include "concore2full/detail/copyable_spawn_frame_base.h"
+#include "concore2full/detail/atomic_wait.h"
+#include "concore2full/global_thread_pool.h"
+#include "concore2full/profiling.h"
+
+#include <chrono>
+#include <cstring>
+
+namespace {
+
+using concore2full::detail::callcc;
+using concore2full::detail::continuation_t;
+using concore2full::detail::copyable_spawn_frame_base;
+
+/*
+Valid transitions:
+ss_initial_state -> ss_async_started --> ss_async_finished
+*/
+enum sync_state_values {
+  ss_initial_state = 0,
+  ss_async_started,
+  ss_async_finished,
+};
+
+} // namespace
+
+void copyable_spawn_frame_base::spawn(concore2full_spawn_function_t f) {
+  task_.task_function_ = &execute_spawn_task;
+  task_.next_ = nullptr;
+  sync_state_ = ss_initial_state;
+  user_function_ = f;
+  concore2full::global_thread_pool().enqueue(&task_);
+}
+void copyable_spawn_frame_base::await() {
+  concore2full::profiling::zone zone{CURRENT_LOCATION()};
+  // If the async work has already finished, complete directly.
+  if (sync_state_.load(std::memory_order_acquire) == ss_async_finished) {
+    return;
+  }
+
+  // Suspend the current thread; let the worker wake us up,
+  suspend(suspend_token_);
+}
+
+//! Called when the async work is finished, to see if we need a thread switch.
+continuation_t copyable_spawn_frame_base::on_async_complete(continuation_t c) {
+  concore2full::profiling::zone zone{CURRENT_LOCATION()};
+
+  // Tell the world that the computation has finished.
+  sync_state_.store(ss_async_finished, std::memory_order_release);
+
+  // Notify all the waiting futures.
+  suspend_token_.notify();
+  // TODO: the `this` object might become invalid if all the futures are destroyed.
+  return c;
+}
+
+//! The task function that executes the async work.
+void copyable_spawn_frame_base::execute_spawn_task(concore2full_task* task, int) noexcept {
+  auto self =
+      (copyable_spawn_frame_base*)((char*)task - offsetof(copyable_spawn_frame_base, task_));
+  (void)callcc([self](continuation_t thread_cont) -> continuation_t {
+    // Assume there will be a thread switch and store required objects.
+    // self->secondary_thread_ = thread_cont;
+    // Signal the fact that we have started (and the continuation is properly stored).
+    atomic_store_explicit(&self->sync_state_, ss_async_started, std::memory_order_release);
+    // Actually execute the given work.
+    self->user_function_(self->to_interface());
+    // Complete the async processing.
+    return self->on_async_complete(thread_cont);
+  });
+}

--- a/src/copyable_spawn_frame_base.cpp
+++ b/src/copyable_spawn_frame_base.cpp
@@ -64,10 +64,11 @@ void copyable_spawn_frame_base::await() {
       // We are the first to finish; we need to start switching threads.
       auto c = callcc([this](continuation_t await_cc) -> continuation_t {
         first_await_ = await_cc;
+        auto continue_with = secondary_thread_;
         // We are done "finishing".
         sync_state_.store(ss_main_finished, std::memory_order_release);
         // Complete the thread switching.
-        return secondary_thread_;
+        return continue_with;
       });
       (void)c;
     } else {
@@ -86,7 +87,7 @@ void copyable_spawn_frame_base::await() {
     }
 
     // Suspend the current thread; let the worker wake us up,
-    suspend(suspend_token_);
+    suspend_quick_resume(suspend_token_);
   }
 }
 

--- a/src/suspend.cpp
+++ b/src/suspend.cpp
@@ -1,7 +1,31 @@
 #include "concore2full/suspend.h"
+#include "concore2full/detail/atomic_wait.h"
+#include "concore2full/detail/callcc.h"
 #include "concore2full/global_thread_pool.h"
 
 namespace concore2full {
+
+namespace detail {
+struct quick_resume_task : concore2full_task {
+  explicit quick_resume_task(continuation_t c) : cont_(c) { task_function_ = &execute; }
+
+  static void execute(struct concore2full_task* task, int worker_index) {
+    auto* self = static_cast<quick_resume_task*>(task);
+    callcc([self](continuation_t c) -> continuation_t {
+      auto next = self->cont_;
+      // Store the continuation after the task execution.
+      self->after_execute_.store(c, std::memory_order_release);
+      // After this store, the `self` object can be destroyed.
+      // Jump to the point we want to resume.
+      return next;
+    });
+  }
+
+  continuation_t cont_;
+  std::atomic<continuation_t> after_execute_{nullptr};
+};
+} // namespace detail
+
 void suspend_token::notify() { stop_source_.request_stop(); }
 
 void suspend(suspend_token& token) {
@@ -9,6 +33,55 @@ void suspend(suspend_token& token) {
   if (token.stop_source_.stop_requested())
     return;
   global_thread_pool().offer_help_until(token.stop_source_.get_token());
+}
+
+void suspend_quick_resume(suspend_token& token) {
+  concore2full::profiling::zone zone{CURRENT_LOCATION()};
+  auto stop_token = token.stop_source_.get_token();
+  (void)detail::callcc([stop_token](
+                           detail::continuation_t after_suspend) -> detail::continuation_t {
+    // If we are already stopped, return immediately.
+    if (stop_token.stop_requested())
+      return after_suspend;
+
+    detail::quick_resume_task task{after_suspend};
+    enum { initial_state = 0, task_enqueuing, task_enqueued, task_not_needed };
+    std::atomic<int> task_state{initial_state};
+
+    // Register a stop callback that will spawn a new task to jump to the point after suspend.
+    std::stop_callback cb{stop_token, [&task, &task_state]() {
+                            int expected = initial_state;
+                            if (task_state.compare_exchange_strong(expected, task_enqueuing,
+                                                                   std::memory_order_release,
+                                                                   std::memory_order_acquire)) {
+                              concore2full::global_thread_pool().enqueue(&task);
+                              task_state.store(task_enqueued, std::memory_order_release);
+                            }
+                          }};
+
+    global_thread_pool().offer_help_until(stop_token);
+
+    // Did the callback got a chance to run?
+    int expected = initial_state;
+    if (task_state.compare_exchange_strong(expected, task_not_needed, std::memory_order_acquire)) {
+      // The callback didn't run; we can just return in the same stack.
+      return after_suspend;
+    }
+
+    // When we wake up, try to steal the task.
+    // First, wait for the task to be enqueued.
+    concore2full::detail::atomic_wait(task_state, [](int s) { return s == task_enqueued; });
+    if (concore2full::global_thread_pool().extract_task(&task)) {
+      // All good; we can just return in the same stack.
+      return after_suspend;
+    } else {
+      // If the task got the chance to run, then we need to resume at the point that the task
+      // left it. Wait until the continuation is set
+      concore2full::detail::atomic_wait(task.after_execute_,
+                                        [](detail::continuation_t c) { return c != nullptr; });
+      return task.after_execute_.load(std::memory_order_acquire);
+    }
+  });
 }
 
 } // namespace concore2full

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,9 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(Catch2)
 
+# Enable this to disable the POSIX signals in Catch2
+# target_compile_definitions(Catch2 PUBLIC CATCH_CONFIG_NO_POSIX_SIGNALS)
+
 # Add the tests executable
 add_executable(test.concore2full ${sourceFiles})
 target_link_libraries(test.concore2full PRIVATE concore2full Catch2::Catch2WithMain)

--- a/test/test_bulk_spawn.cpp
+++ b/test/test_bulk_spawn.cpp
@@ -35,7 +35,7 @@ auto create_op(int count, std::atomic<int>& sum) {
 
 template <typename Op> void receiver(Op&& op) { std::forward<Op>(op).await(); }
 
-TEST_CASE("bulk_spawn result can be returned from functions", "[spawn]") {
+TEST_CASE("bulk_spawn result can be returned from functions", "[bulk_spawn]") {
   // Arrange
   std::atomic<int> sum{0};
   // Act

--- a/test/test_spawn.cpp
+++ b/test/test_spawn.cpp
@@ -1,13 +1,17 @@
+#include "concore2full/profiling.h"
 #include "concore2full/spawn.h"
+#include "concore2full/global_thread_pool.h"
 
 #include <catch2/catch_test_macros.hpp>
 
 #include <chrono>
+#include <latch>
 #include <semaphore>
 
 using namespace std::chrono_literals;
 
 TEST_CASE("spawn can execute work", "[spawn]") {
+  concore2full::profiling::zone zone{CURRENT_LOCATION()};
   // Arrange
   bool called{false};
   std::binary_semaphore done{0};
@@ -28,6 +32,7 @@ TEST_CASE("spawn can execute work", "[spawn]") {
 }
 
 TEST_CASE("spawn can execute work with void result", "[spawn]") {
+  concore2full::profiling::zone zone{CURRENT_LOCATION()};
   // Arrange
   bool called{false};
   std::binary_semaphore done{0};
@@ -45,6 +50,7 @@ TEST_CASE("spawn can execute work with void result", "[spawn]") {
 }
 
 TEST_CASE("spawn can execute a function that returns a reference", "[spawn]") {
+  concore2full::profiling::zone zone{CURRENT_LOCATION()};
   // Arrange
   bool called{false};
   std::binary_semaphore done{0};
@@ -66,6 +72,7 @@ TEST_CASE("spawn can execute a function that returns a reference", "[spawn]") {
 }
 
 TEST_CASE("escaping_spawn can execute work", "[spawn]") {
+  concore2full::profiling::zone zone{CURRENT_LOCATION()};
   // Arrange
   bool called{false};
   std::binary_semaphore done{0};
@@ -86,6 +93,7 @@ TEST_CASE("escaping_spawn can execute work", "[spawn]") {
 }
 
 TEST_CASE("escaping_spawn can execute work with void result", "[spawn]") {
+  concore2full::profiling::zone zone{CURRENT_LOCATION()};
   // Arrange
   bool called{false};
   std::binary_semaphore done{0};
@@ -103,6 +111,7 @@ TEST_CASE("escaping_spawn can execute work with void result", "[spawn]") {
 }
 
 TEST_CASE("escaping_spawn can execute a function that returns a reference", "[spawn]") {
+  concore2full::profiling::zone zone{CURRENT_LOCATION()};
   // Arrange
   bool called{false};
   std::binary_semaphore done{0};
@@ -130,10 +139,116 @@ auto create_op() {
 template <typename Op> auto receiver(Op op) { return op.await(); }
 
 TEST_CASE("escaping_spawn result can be returned from functions", "[spawn]") {
+  concore2full::profiling::zone zone{CURRENT_LOCATION()};
   // Act
   auto future = create_op();
   auto res = receiver(std::move(future));
 
   // Assert
   REQUIRE(res == 13);
+}
+
+TEST_CASE("a copyable_spawn future can be copied", "[spawn]") {
+  concore2full::profiling::zone zone{CURRENT_LOCATION()};
+  (void)concore2full::global_thread_pool(); // ensure we have a valid thread pool
+
+  // Act
+  auto f{concore2full::copyable_spawn([&]() -> int { return 13; })};
+  auto f2 = f;
+  auto f3 = f;
+
+  // Assert
+  REQUIRE(f.await() == 13);
+  REQUIRE(f2.await() == 13);
+  REQUIRE(f3.await() == 13);
+
+  concore2full::global_thread_pool().join();
+}
+
+TEST_CASE("copyable_spawn: multiple awaits while the task is not done yet", "[spawn]") {
+  concore2full::profiling::zone zone{CURRENT_LOCATION()};
+  // Arrange
+  (void)concore2full::global_thread_pool(); // ensure we have a valid thread pool
+  std::latch l{4};
+  int res1{-1};
+  int res2{-1};
+  int res3{-1};
+
+  // Act
+  auto f{concore2full::copyable_spawn([&]() -> int {
+    concore2full::profiling::zone zone{CURRENT_LOCATION_N("task")};
+    l.arrive_and_wait();
+    return 13;
+  })};
+  auto t1 = std::thread([&l, &res1, f]() mutable {
+    concore2full::profiling::zone zone{CURRENT_LOCATION_N("thread1")};
+    l.arrive_and_wait();
+    res1 = f.await();
+  });
+  auto t2 = std::thread([&l, &res2, f]() mutable {
+    concore2full::profiling::zone zone{CURRENT_LOCATION_N("thread2")};
+    l.arrive_and_wait();
+    res2 = f.await();
+  });
+  auto t3 = std::thread([&l, &res3, f]() mutable {
+    concore2full::profiling::zone zone{CURRENT_LOCATION_N("thread3")};
+    l.arrive_and_wait();
+    res3 = f.await();
+  });
+  t1.join();
+  t2.join();
+  t3.join();
+
+  // Assert
+  REQUIRE(res1 == 13);
+  REQUIRE(res2 == 13);
+  REQUIRE(res3 == 13);
+
+  concore2full::global_thread_pool().join();
+}
+
+TEST_CASE("copyable_spawn: multiple awaits unlocked by finishing the computation", "[spawn]") {
+  concore2full::profiling::zone zone{CURRENT_LOCATION()};
+  // Arrange
+  (void)concore2full::global_thread_pool(); // ensure we have a valid thread pool
+  std::latch l{4};
+  std::binary_semaphore can_finish{0};
+  int res1{-1};
+  int res2{-1};
+  int res3{-1};
+
+  // Act
+  auto f{concore2full::copyable_spawn([&]() -> int {
+    concore2full::profiling::zone zone{CURRENT_LOCATION_N("task")};
+    can_finish.acquire();
+    return 13;
+  })};
+  auto t1 = std::thread([&l, &res1, f]() mutable {
+    concore2full::profiling::zone zone{CURRENT_LOCATION_N("thread1")};
+    l.arrive_and_wait();
+    res1 = f.await();
+  });
+  auto t2 = std::thread([&l, &res2, f]() mutable {
+    concore2full::profiling::zone zone{CURRENT_LOCATION_N("thread2")};
+    l.arrive_and_wait();
+    res2 = f.await();
+  });
+  auto t3 = std::thread([&l, &res3, f]() mutable {
+    concore2full::profiling::zone zone{CURRENT_LOCATION_N("thread3")};
+    l.arrive_and_wait();
+    res3 = f.await();
+  });
+  l.arrive_and_wait(); // all the threads reached the await point
+  std::this_thread::sleep_for(100us);
+  can_finish.release(); // let the task finish
+  t1.join();
+  t2.join();
+  t3.join();
+
+  // Assert
+  REQUIRE(res1 == 13);
+  REQUIRE(res2 == 13);
+  REQUIRE(res3 == 13);
+
+  concore2full::global_thread_pool().join();
 }

--- a/test/test_suspend.cpp
+++ b/test/test_suspend.cpp
@@ -7,62 +7,58 @@
 
 #include <semaphore>
 
-TEST_CASE("suspend actually suspends the thread of execution", "[suspend]") {
-  concore2full::profiling::zone zone{CURRENT_LOCATION()};
+// TEST_CASE("suspend actually suspends the thread of execution", "[suspend]") {
+//   concore2full::profiling::zone zone{CURRENT_LOCATION()};
 
-  // Arrange
-  (void)concore2full::global_thread_pool(); // ensure we have a valid thread pool
-  concore2full::suspend_token* token_ptr{nullptr};
-  std::binary_semaphore token_created{0};
-  std::atomic<int> counter{0};
-  int before_suspend_value{-1};
-  int after_suspend_value{-1};
-  int before_notify_value{-1};
-  int after_notify_value{-1};
+//   // Arrange
+//   concore2full::suspend_token* token_ptr{nullptr};
+//   std::binary_semaphore token_created{0};
+//   std::atomic<int> counter{0};
+//   int before_suspend_value{-1};
+//   int after_suspend_value{-1};
+//   int before_notify_value{-1};
+//   int after_notify_value{-1};
 
-  // Act
-  std::thread thread_to_suspend{[&] {
-    concore2full::profiling::zone zone{CURRENT_LOCATION_N("thread_to_suspend")};
-    concore2full::sync_execute([&] {
-      concore2full::profiling::zone z2{CURRENT_LOCATION()};
-      before_suspend_value = counter++;
-      concore2full::suspend_token token;
-      token_ptr = &token;
-      token_created.release();
-      concore2full::suspend(token);
-      after_suspend_value = counter++;
-    });
-  }};
-  std::thread notifying_thread{[&] {
-    concore2full::profiling::zone zone{CURRENT_LOCATION_N("notifying_thread")};
-    token_created.acquire();
-    before_notify_value = counter++;
-    token_ptr->notify();
-    after_notify_value = counter++;
-  }};
-  thread_to_suspend.join();
-  notifying_thread.join();
+//   // Act
+//   std::thread thread_to_suspend{[&] {
+//     concore2full::profiling::zone zone{CURRENT_LOCATION_N("thread_to_suspend")};
+//     concore2full::sync_execute([&] {
+//       concore2full::profiling::zone z2{CURRENT_LOCATION()};
+//       before_suspend_value = counter++;
+//       concore2full::suspend_token token;
+//       token_ptr = &token;
+//       token_created.release();
+//       concore2full::suspend(token);
+//       after_suspend_value = counter++;
+//     });
+//   }};
+//   std::thread notifying_thread{[&] {
+//     concore2full::profiling::zone zone{CURRENT_LOCATION_N("notifying_thread")};
+//     token_created.acquire();
+//     before_notify_value = counter++;
+//     token_ptr->notify();
+//     after_notify_value = counter++;
+//   }};
+//   thread_to_suspend.join();
+//   notifying_thread.join();
 
-  // Assert
-  REQUIRE(before_suspend_value == 0);
-  REQUIRE(before_notify_value == 1);
-  if (after_suspend_value == 2) {
-    REQUIRE(after_suspend_value == 2);
-    REQUIRE(after_notify_value == 3);
-  } else {
-    REQUIRE(after_suspend_value == 3);
-    REQUIRE(after_notify_value == 2);
-  }
-  REQUIRE(counter.load(std::memory_order_relaxed) == 4);
-
-  concore2full::global_thread_pool().join();
-}
+//   // Assert
+//   REQUIRE(before_suspend_value == 0);
+//   REQUIRE(before_notify_value == 1);
+//   if (after_suspend_value == 2) {
+//     REQUIRE(after_suspend_value == 2);
+//     REQUIRE(after_notify_value == 3);
+//   } else {
+//     REQUIRE(after_suspend_value == 3);
+//     REQUIRE(after_notify_value == 2);
+//   }
+//   REQUIRE(counter.load(std::memory_order_relaxed) == 4);
+// }
 
 TEST_CASE("notify is called before suspend", "[suspend]") {
   concore2full::profiling::zone zone{CURRENT_LOCATION()};
 
   // Arrange
-  (void)concore2full::global_thread_pool(); // ensure we have a valid thread pool
   concore2full::suspend_token* token_ptr{nullptr};
   bool reched_after_suspend{false};
   std::binary_semaphore token_created{0};
@@ -100,6 +96,4 @@ TEST_CASE("notify is called before suspend", "[suspend]") {
 
   // Assert
   REQUIRE(reched_after_suspend);
-
-  concore2full::global_thread_pool().join();
 }

--- a/test/test_suspend.cpp
+++ b/test/test_suspend.cpp
@@ -7,56 +7,62 @@
 
 #include <semaphore>
 
-// TEST_CASE("suspend actually suspends the thread of execution", "[suspend]") {
-//   concore2full::profiling::zone zone{CURRENT_LOCATION()};
+TEST_CASE("suspend actually suspends the thread of execution", "[suspend]") {
+  concore2full::profiling::zone zone{CURRENT_LOCATION()};
 
-//   // Arrange
-//   concore2full::suspend_token* token_ptr{nullptr};
-//   std::binary_semaphore token_created{0};
-//   std::atomic<int> counter{0};
-//   int before_suspend_value{-1};
-//   int after_suspend_value{-1};
-//   int before_notify_value{-1};
-//   int after_notify_value{-1};
+  // Ensure we have a valid thread pool (and not create it on a worker thread).
+  (void)concore2full::global_thread_pool();
 
-//   // Act
-//   std::thread thread_to_suspend{[&] {
-//     concore2full::profiling::zone zone{CURRENT_LOCATION_N("thread_to_suspend")};
-//     concore2full::sync_execute([&] {
-//       concore2full::profiling::zone z2{CURRENT_LOCATION()};
-//       before_suspend_value = counter++;
-//       concore2full::suspend_token token;
-//       token_ptr = &token;
-//       token_created.release();
-//       concore2full::suspend(token);
-//       after_suspend_value = counter++;
-//     });
-//   }};
-//   std::thread notifying_thread{[&] {
-//     concore2full::profiling::zone zone{CURRENT_LOCATION_N("notifying_thread")};
-//     token_created.acquire();
-//     before_notify_value = counter++;
-//     token_ptr->notify();
-//     after_notify_value = counter++;
-//   }};
-//   thread_to_suspend.join();
-//   notifying_thread.join();
+  // Arrange
+  concore2full::suspend_token* token_ptr{nullptr};
+  std::binary_semaphore token_created{0};
+  std::atomic<int> counter{0};
+  int before_suspend_value{-1};
+  int after_suspend_value{-1};
+  int before_notify_value{-1};
+  int after_notify_value{-1};
 
-//   // Assert
-//   REQUIRE(before_suspend_value == 0);
-//   REQUIRE(before_notify_value == 1);
-//   if (after_suspend_value == 2) {
-//     REQUIRE(after_suspend_value == 2);
-//     REQUIRE(after_notify_value == 3);
-//   } else {
-//     REQUIRE(after_suspend_value == 3);
-//     REQUIRE(after_notify_value == 2);
-//   }
-//   REQUIRE(counter.load(std::memory_order_relaxed) == 4);
-// }
+  // Act
+  std::thread thread_to_suspend{[&] {
+    concore2full::profiling::zone zone{CURRENT_LOCATION_N("thread_to_suspend")};
+    concore2full::sync_execute([&] {
+      concore2full::profiling::zone z2{CURRENT_LOCATION()};
+      before_suspend_value = counter++;
+      concore2full::suspend_token token;
+      token_ptr = &token;
+      token_created.release();
+      concore2full::suspend(token);
+      after_suspend_value = counter++;
+    });
+  }};
+  std::thread notifying_thread{[&] {
+    concore2full::profiling::zone zone{CURRENT_LOCATION_N("notifying_thread")};
+    token_created.acquire();
+    before_notify_value = counter++;
+    token_ptr->notify();
+    after_notify_value = counter++;
+  }};
+  thread_to_suspend.join();
+  notifying_thread.join();
+
+  // Assert
+  REQUIRE(before_suspend_value == 0);
+  REQUIRE(before_notify_value == 1);
+  if (after_suspend_value == 2) {
+    REQUIRE(after_suspend_value == 2);
+    REQUIRE(after_notify_value == 3);
+  } else {
+    REQUIRE(after_suspend_value == 3);
+    REQUIRE(after_notify_value == 2);
+  }
+  REQUIRE(counter.load(std::memory_order_relaxed) == 4);
+}
 
 TEST_CASE("notify is called before suspend", "[suspend]") {
   concore2full::profiling::zone zone{CURRENT_LOCATION()};
+
+  // Ensure we have a valid thread pool (and not create it on a worker thread).
+  (void)concore2full::global_thread_pool();
 
   // Arrange
   concore2full::suspend_token* token_ptr{nullptr};


### PR DESCRIPTION
Add a spawn that produces futures that can be copied.

We also have support for suspending the current thread and resuming on some external event. This is helpful for implementing async I/O